### PR TITLE
feat: add GitHub Pages deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      pages: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -38,6 +40,29 @@ jobs:
           zip -r ../CleanClip-${VERSION}.zip .
 
       - name: Semantic Release
+        id: semantic
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release
+
+      - name: Get released version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Released version: $VERSION"
+
+      - name: Prepare GitHub Pages
+        run: |
+          mkdir -p _site
+          cp landing/* _site/
+          sed -i "s/__VERSION__/${{ steps.version.outputs.version }}/g" _site/index.html
+          echo "Version updated in landing page"
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4

--- a/landing/index.html
+++ b/landing/index.html
@@ -385,13 +385,13 @@
             <p class="description">
                 A Chrome extension that extracts text from any image or screen area using AI-powered OCR. Copy clean, formatted text to your clipboard in seconds.
             </p>
-            <a href="CleanClip-0.7.0.zip" class="download-btn" download>
+            <a href="https://github.com/frankyxhl/CleanClip/releases/download/v__VERSION__/CleanClip-__VERSION__.zip" class="download-btn">
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
                 </svg>
                 Download for Chrome
             </a>
-            <p class="version">Version 0.7.0 <span class="badge">Early Preview</span></p>
+            <p class="version">Version __VERSION__ <span class="badge">Early Preview</span></p>
         </section>
     </div>
 

--- a/scripts/deploy-pages.sh
+++ b/scripts/deploy-pages.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Deploy landing page to GitHub Pages (gh-pages branch)
+# Usage: ./scripts/deploy-pages.sh <version>
+#
+# This script:
+# 1. Copies landing/ to a temp directory
+# 2. Replaces __VERSION__ placeholder with actual version
+# 3. Pushes to gh-pages branch
+
+set -e
+
+VERSION="${1:-}"
+if [ -z "$VERSION" ]; then
+    echo "Usage: $0 <version>"
+    echo "Example: $0 0.8.0"
+    exit 1
+fi
+
+echo "Deploying version $VERSION to GitHub Pages..."
+
+# Create temp directory
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf $TEMP_DIR" EXIT
+
+# Copy landing files
+cp -r landing/* "$TEMP_DIR/"
+
+# Replace version placeholder
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS
+    sed -i '' "s/__VERSION__/$VERSION/g" "$TEMP_DIR/index.html"
+else
+    # Linux
+    sed -i "s/__VERSION__/$VERSION/g" "$TEMP_DIR/index.html"
+fi
+
+echo "Version placeholder replaced in index.html"
+
+# Setup git for gh-pages
+cd "$TEMP_DIR"
+git init
+git checkout -b gh-pages
+git add -A
+git commit -m "Deploy v$VERSION"
+
+# Push to gh-pages branch (force push since it's a new orphan commit each time)
+git push -f "git@github.com:frankyxhl/CleanClip.git" gh-pages
+
+echo "✅ Deployed v$VERSION to https://frankyxhl.github.io/CleanClip/"


### PR DESCRIPTION
## Summary
- Add GitHub Pages deployment for project website
- Landing page now uses `__VERSION__` placeholder for auto-updating
- Download link points to GitHub Releases

## Changes
- `landing/index.html` - Version placeholder, GitHub Releases download link
- `.github/workflows/release.yml` - Auto-deploy to Pages after release
- `scripts/deploy-pages.sh` - Manual deployment script (optional)

## How it works
1. When a PR is merged to main, release workflow runs
2. Semantic-release creates new version
3. Pages are deployed with updated version number
4. Website URL: https://frankyxhl.github.io/CleanClip/

## Test plan
- [ ] CI passes
- [ ] After merge, website is deployed
- [ ] Version number is correct on website
- [ ] Download link works

---
Generated with [Claude Code](https://claude.com/claude-code)