### PR TITLE
fix: correct README icon path for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="public/icon128.png" alt="CleanClip Logo" width="128" height="128">
+  <img src="icon128.png" alt="CleanClip Logo" width="128" height="128">
 </p>
 
 # CleanClip


### PR DESCRIPTION
## Summary
- Fixed icon path in README.md from `public/icon128.png` to `icon128.png` to match the GitHub Pages deployment

## Problem
The README was referencing `public/icon128.png`, but the deployed GitHub Pages site at https://frankyxhl.github.io/CleanClip/ uses `icon128.png` at the root level. This caused the icon to display incorrectly on the deployed site.

## Solution
Updated the image source path in README.md to use the correct root-level path that matches the actual deployment structure.

## Test plan
- [x] Verified icon path on GitHub Pages site
- [x] Updated README.md with correct path
- [ ] After merge, verify icon displays correctly on both GitHub repository and GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)