### PR TITLE
fix: trigger CI on release-please branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  push:
+    branches:
+      - 'release-please--**'
 
 jobs:
   build-and-test:


### PR DESCRIPTION
## Summary
GitHub Actions created PRs don't trigger other workflows for security reasons.
This causes Release PRs to not have the required `build-and-test` status check.

## Fix
Add push trigger on `release-please--**` branches to run CI checks.

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, Release PR #9 should have CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)