### PR TITLE
fix: add issues:write permission for release-please comments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write  # Required for release-please to add comments to PRs
   pages: write
   id-token: write
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -924,9 +924,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.28",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.28.tgz",
-      "integrity": "sha512-VyKBr25BuFDzBFCK5sUM6ZXiWfqgCTwTAOK8qzGV/m9FCirXYDlmczJ+d5dXBAQALGCdRRdbteKYfJ84NGEusw==",
+      "version": "20.19.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.29.tgz",
+      "integrity": "sha512-YrT9ArrGaHForBaCNwFjoqJWmn8G1Pr7+BH/vwyLHciA9qT/wSiuOhxGCT50JA5xLvFBd6PIiGkE3afxcPE1nw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1546,9 +1546,9 @@
       "license": "ISC"
     },
     "node_modules/happy-dom": {
-      "version": "20.1.0",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.1.0.tgz",
-      "integrity": "sha512-ebvqjBqzenBk2LjzNEAzoj7yhw7rW/R2/wVevMu6Mrq3MXtcI/RUz4+ozpcOcqVLEWPqLfg2v9EAU7fFXZUUJw==",
+      "version": "20.3.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.3.0.tgz",
+      "integrity": "sha512-5qJbkqcvR8j/a4av5IWqqIWmEGf9dt6OhGMS6qxCgjSOBGzGa5XLoqg40OyD8XNzQ+g1g2zsXi10kjfpzYH55Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Add `issues: write` permission to release.yml workflow
- Fixes release-please failing to add comments to PRs

## Related Issue
Fixes CI failure: https://github.com/frankyxhl/CleanClip/actions/runs/21033347159

## Test Plan
- [ ] Merge to develop, then to main
- [ ] Verify release-please can add comments to PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)