### PR TITLE
chore: use GITHUB_TOKEN for release-please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   build-and-publish:
     needs: release-please


### PR DESCRIPTION
## Summary
- Use `GITHUB_TOKEN` instead of `GH_TOKEN` for release-please workflow

## Test plan
- Verify CI passes
- Release workflow will trigger correctly on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)