### PR TITLE
chore(deps): update patch versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -924,9 +924,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.29.tgz",
-      "integrity": "sha512-YrT9ArrGaHForBaCNwFjoqJWmn8G1Pr7+BH/vwyLHciA9qT/wSiuOhxGCT50JA5xLvFBd6PIiGkE3afxcPE1nw==",
+      "version": "20.19.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
+      "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1546,9 +1546,9 @@
       "license": "ISC"
     },
     "node_modules/happy-dom": {
-      "version": "20.3.0",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.3.0.tgz",
-      "integrity": "sha512-5qJbkqcvR8j/a4av5IWqqIWmEGf9dt6OhGMS6qxCgjSOBGzGa5XLoqg40OyD8XNzQ+g1g2zsXi10kjfpzYH55Q==",
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.3.1.tgz",
+      "integrity": "sha512-tLvsizNno05Hij0PoB0QN/S8xf0YU2AGvO11/JlJDw5McA/gzyn0Ni1RwbTI1/zteUbOekJH0t6q8HFvjbxsGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Update patch versions of dev dependencies

## Changes
- `@types/node`: 20.19.29 → 20.19.30
- `happy-dom`: 20.3.0 → 20.3.1

## Test plan
- [x] `npm test` passes (CI will verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)