### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,0 +1,110 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the form below to help us fix it.
+
+  - type: dropdown
+    id: browser
+    attributes:
+      label: Browser
+      description: Which browser are you using?
+      options:
+        - Chrome
+        - Edge
+        - Brave
+        - Arc
+        - Other Chromium-based browser
+    validations:
+      required: true
+
+  - type: input
+    id: browser-version
+    attributes:
+      label: Browser Version
+      description: "You can find this in browser settings or by visiting chrome://version"
+      placeholder: "e.g., 120.0.6099.109"
+    validations:
+      required: true
+
+  - type: input
+    id: extension-version
+    attributes:
+      label: Extension Version
+      description: "Find this in chrome://extensions (enable Developer mode)"
+      placeholder: "e.g., 0.12.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - macOS
+        - Windows
+        - Linux
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear description of what the bug is
+      placeholder: Describe the bug...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this issue?
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain the problem (drag & drop images here)
+
+  - type: textarea
+    id: console-errors
+    attributes:
+      label: Console Errors
+      description: |
+        Open DevTools (F12) → Console tab, and paste any error messages here.
+        For background script errors: chrome://extensions → CleanClip → "Inspect views: service worker"
+      render: shell
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context about the problem

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,0 +1,71 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please fill out the form below.
+
+  - type: dropdown
+    id: feature-type
+    attributes:
+      label: Feature Type
+      description: What kind of feature is this?
+      options:
+        - New OCR capability
+        - UI/UX improvement
+        - New output format
+        - Integration with other tools
+        - Performance improvement
+        - Accessibility
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or Use Case
+      description: What problem does this feature solve? Or describe your use case.
+      placeholder: "I'm always frustrated when..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or features you've considered?
+
+  - type: textarea
+    id: mockups
+    attributes:
+      label: Mockups / Examples
+      description: If applicable, add mockups, screenshots, or examples (drag & drop images here)
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: How important is this feature to you?
+      options:
+        - Nice to have
+        - Important - affects my workflow
+        - Critical - blocking my use of the extension
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context about the feature request

--- a/.github/ISSUE_TEMPLATE/3-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/3-documentation.yml
@@ -1,0 +1,58 @@
+name: Documentation
+description: Report documentation issues or suggest improvements
+title: "[Docs]: "
+labels: ["documentation", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Help us improve the documentation!
+
+  - type: dropdown
+    id: doc-type
+    attributes:
+      label: Documentation Type
+      options:
+        - README
+        - Installation guide
+        - Usage instructions
+        - API documentation
+        - Contributing guide
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Issue Type
+      options:
+        - Missing information
+        - Incorrect information
+        - Outdated information
+        - Unclear or confusing
+        - Typo or grammar
+        - Suggestion for new documentation
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: Location
+      description: Where is this documentation located? (URL or file path)
+      placeholder: "e.g., README.md or https://github.com/frankyxhl/CleanClip#installation"
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the issue or improvement
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested Change
+      description: If you have a specific suggestion, please describe it here

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question / Help
+    url: https://github.com/frankyxhl/CleanClip/discussions/new?category=q-a
+    about: Ask questions and get help from the community
+  - name: Ideas / Feedback
+    url: https://github.com/frankyxhl/CleanClip/discussions/new?category=ideas
+    about: Share ideas and feedback for CleanClip


### PR DESCRIPTION
## Summary
Add structured GitHub issue templates using YAML forms for better issue quality and user experience.

## Templates Added

| Template | File | Purpose |
|----------|------|---------|
| 🐛 Bug Report | `1-bug-report.yml` | Structured bug reports with browser/OS/version info |
| ✨ Feature Request | `2-feature-request.yml` | Feature suggestions with use case and priority |
| 📖 Documentation | `3-documentation.yml` | Documentation issues and improvements |

## Configuration (`config.yml`)
- **Disabled blank issues** - Users must use templates
- **External links** - Q&A and Ideas redirect to GitHub Discussions

## Bug Report Fields
- Browser (dropdown: Chrome, Edge, Brave, Arc)
- Browser Version
- Extension Version
- Operating System
- Bug Description
- Steps to Reproduce
- Expected vs Actual Behavior
- Screenshots (optional)
- Console Errors (optional)

## Preview
After merging, the "New Issue" page will show a template chooser:

![Issue Template Chooser](https://docs.github.com/assets/cb-35498/mw-1440/images/help/repository/issue-template-chooser.webp)

## Test Plan
- [ ] Verify templates appear at https://github.com/frankyxhl/CleanClip/issues/new/choose
- [ ] Test bug report form validation
- [ ] Test feature request form
- [ ] Verify external links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)